### PR TITLE
Prepopulate tiles with food.

### DIFF
--- a/EvolvioColor/Board.pde
+++ b/EvolvioColor/Board.pde
@@ -75,7 +75,7 @@ class Board {
         float fertility = noise(x * stepSize * 3, y * stepSize * 3) * (1 - bigForce) * 5.0 + noise(x * stepSize * 0.5, y * stepSize * 0.5) * bigForce * 5.0 - 1.5;
         float climateType = noise(x * stepSize * 0.2 + 10000, y * stepSize * 0.2 + 10000) * 1.63 - 0.4;
         climateType = min(max(climateType, 0), 0.8);
-        tiles[x][y] = new Tile(x, y, fertility, 0, climateType, this);
+        tiles[x][y] = new Tile(x, y, fertility, climateType, this);
       }
     }
     MIN_TEMPERATURE = min;

--- a/EvolvioColor/Tile.pde
+++ b/EvolvioColor/Tile.pde
@@ -17,11 +17,11 @@ class Tile {
 
   Board board;
 
-  public Tile(int x, int y, double f, float food, float type, Board b) {
+  public Tile(int x, int y, double f, float type, Board b) {
     posX = x;
     posY = y;
     fertility = Math.max(0, f);
-    foodLevel = Math.max(0, food);
+    foodLevel = fertility;
     climateType = foodType = type;
     board = b;
   }


### PR DESCRIPTION
Removes a hardcoded 0 and eliminates an artificial famine when the simulation first starts.