### PR TITLE
Fix text save bug and add file load feature.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -16,5 +16,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="core.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/evolv/io/Axon.java
+++ b/src/evolv/io/Axon.java
@@ -1,6 +1,10 @@
 package evolv.io;
 
-class Axon {
+class Axon implements java.io.Serializable {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -1369840006114199775L;
 	final double MUTABILITY_MUTABILITY = 0.7f;
 	final int mutatePower = 9;
 	final double MUTATE_MULTI;
@@ -25,5 +29,5 @@ class Axon {
 
 	public double pmRan() {
 		return Math.random() * 2 - 1;
-	}
+	}	
 }

--- a/src/evolv/io/Brain.java
+++ b/src/evolv/io/Brain.java
@@ -4,11 +4,15 @@ import java.util.ArrayList;
 
 import processing.core.PFont;
 
-class Brain {
+class Brain implements java.io.Serializable{
 	/**
 	 * 
 	 */
-	private final EvolvioColor evolvioColor;
+	private static final long serialVersionUID = -4169230432277897483L;
+	/**
+	 * 
+	 */
+	public EvolvioColor evolvioColor;
 	// Brain
 	final int MEMORY_COUNT = 1;
 	final int BRAIN_WIDTH = 3;

--- a/src/evolv/io/Creature.java
+++ b/src/evolv/io/Creature.java
@@ -4,11 +4,15 @@ import java.util.ArrayList;
 
 import processing.core.PFont;
 
-class Creature extends SoftBody {
+public class Creature extends SoftBody implements java.io.Serializable{
 	/**
 	 * 
 	 */
-	private final EvolvioColor evolvioColor;
+	private static final long serialVersionUID = 476572589771857421L;
+	/**
+	 * 
+	 */
+	public EvolvioColor evolvioColor;
 	// Energy
 	double ACCELERATION_ENERGY = 0.18f;
 	double ACCELERATION_BACK_ENERGY = 0.24f;
@@ -474,6 +478,7 @@ class Creature extends SoftBody {
 				double newMouthHue = 0;
 				int parentsTotal = parents.size();
 				String[] parentNames = new String[parentsTotal];
+				int[] parentIds= new int[parentsTotal];
 				Brain newBrain = brain.evolve(parents);
 				for (int i = 0; i < parentsTotal; i++) {
 					int chosenIndex = (int) this.evolvioColor.random(0, parents.size());
@@ -487,6 +492,7 @@ class Creature extends SoftBody {
 					newBrightness += parent.brightness / parentsTotal;
 					newMouthHue += parent.mouthHue / parentsTotal;
 					parentNames[i] = parent.name;
+					parentIds[i] = parent.id;
 					if (parent.gen > highestGen) {
 						highestGen = parent.gen;
 					}

--- a/src/evolv/io/FileManager.java
+++ b/src/evolv/io/FileManager.java
@@ -1,0 +1,101 @@
+package evolv.io;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class FileManager implements java.io.Serializable {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -3970782842142170878L;
+
+	EvolvioColor evolvioColor;
+	double year;
+	
+	// Saving
+	int[] fileSaveCounts;
+	double[] fileSaveTimes;
+	double imageSaveInterval = 32;
+	double textSaveInterval = 32;
+	String folder;
+	String[] modes = { "manualImgs", "autoImgs", "manualTexts", "autoTexts" };
+	
+	public FileManager(EvolvioColor evolvioColor, String initialFileName){
+		this.evolvioColor = evolvioColor;
+		folder = initialFileName;
+		fileSaveCounts = new int[4];
+		fileSaveTimes = new double[4];
+		for (int i = 0; i < 4; i++) {
+			fileSaveCounts[i] = 0;
+			fileSaveTimes[i] = -999;
+		}
+	}
+	
+	public Board fileLoad(String filename){
+		Board evoBoard = null;
+		try {
+			FileInputStream fileInputStream = new FileInputStream(filename);
+			ObjectInputStream reader = new ObjectInputStream(fileInputStream);
+			evoBoard = (Board) reader.readObject();
+			reader.close();
+		} catch (ClassNotFoundException | IOException e) {
+			e.printStackTrace();
+		}		
+		return evoBoard;
+	}
+	
+	public String getNextFileName(int type) {		
+		String ending = ".png";
+		if (type >= 2) {
+			ending = ".txt";
+		}
+		return folder + "/" + modes[type] + "/" + EvolvioColor.nf(fileSaveCounts[type], 5) + ending;
+	}
+	
+	// Create the four folders under the new folder where all information will be saved
+	public void setNewSaveDirectory(String filePath){		
+		folder = evolvioColor.INITIAL_FILE_NAME;
+		String fullPath;
+		for (int i = 0; i < modes.length; i++) {
+			fullPath = filePath + "/" + modes[i];	
+			File f = new File(fullPath);
+			if (!f.exists()){
+				try{
+					f.mkdir();
+				} catch(Exception e) {
+				    e.printStackTrace();
+				}
+			} 
+		}		
+	}
+	
+	void prepareForFileSave(int type) {
+		fileSaveTimes[type] = -999999;
+	}
+	
+	// Save entire board or image of frame
+	void fileSave(Board evoBoard) {		
+		for (int i = 0; i < 4; i++) {
+			if (fileSaveTimes[i] < -99999) {
+				fileSaveTimes[i] = year;
+				if (i < 2) {
+					evoBoard.evolvioColor.saveFrame(getNextFileName(i));
+				} else {
+					try{
+						ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(getNextFileName(i)));
+						out.writeObject(evoBoard);
+						out.close();
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+				}
+				this.fileSaveCounts[i]++;
+			}
+		}
+	}
+}

--- a/src/evolv/io/NameGenerator.java
+++ b/src/evolv/io/NameGenerator.java
@@ -1,6 +1,10 @@
 package evolv.io;
 
-class NameGenerator {
+class NameGenerator implements java.io.Serializable {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -6091853690780817687L;
 	/**
 	 * 
 	 */

--- a/src/evolv/io/SoftBody.java
+++ b/src/evolv/io/SoftBody.java
@@ -2,11 +2,15 @@ package evolv.io;
 
 import java.util.ArrayList;
 
-class SoftBody {
+class SoftBody implements java.io.Serializable{
 	/**
 	 * 
 	 */
-	private final EvolvioColor evolvioColor;
+	private static final long serialVersionUID = -1015609094686172150L;
+	/**
+	 * 
+	 */
+	public EvolvioColor evolvioColor;
 	double px;
 	double py;
 	double vx;
@@ -38,7 +42,6 @@ class SoftBody {
 
 	public SoftBody(EvolvioColor evolvioColor, double tpx, double tpy, double tvx, double tvy, double tenergy,
 			double tdensity, double thue, double tsaturation, double tbrightness, Board tb) {
-		this.evolvioColor = evolvioColor;
 		px = tpx;
 		py = tpy;
 		vx = tvx;
@@ -49,6 +52,7 @@ class SoftBody {
 		saturation = tsaturation;
 		brightness = tbrightness;
 		board = tb;
+		this.evolvioColor = tb.evolvioColor;
 		setSBIP(false);
 		setSBIP(false); // Just to set previous SBIPs as well.
 		birthTime = tb.year;
@@ -139,6 +143,7 @@ class SoftBody {
 
 	public void drawSoftBody(float scaleUp) {
 		double radius = getRadius();
+		this.evolvioColor = board.evolvioColor;
 		this.evolvioColor.stroke(0);
 		this.evolvioColor.strokeWeight(board.CREATURE_STROKE_WEIGHT);
 		this.evolvioColor.fill((float) hue, (float) saturation, (float) brightness);

--- a/src/evolv/io/Tile.java
+++ b/src/evolv/io/Tile.java
@@ -1,10 +1,14 @@
 package evolv.io;
 
-class Tile {
+class Tile implements java.io.Serializable {
 	/**
 	 * 
 	 */
-	private final EvolvioColor evolvioColor;
+	private static final long serialVersionUID = 549301346167185645L;
+	/**
+	 * 
+	 */
+	public EvolvioColor evolvioColor;
 	public final int barrenColor;
 	public final int fertileColor;
 	public final int blackColor;


### PR DESCRIPTION
Separate code for saving texts and screenshots into its own file,
FileManager, which also contains code for loading files.

I was considering changing the "PIC" folder to "SAVES," since the stuff under "PIC" also includes non-picture files. 

It works the way you'd expect it to work - if you hit "Load File," a window pops up and you can choose which text file that was previously saved to load. 

I also included a "Change Save Folder" button that lets you choose or create a new folder in which you can save the text and pic files during that current session. 

What will happen is, whatever folder you choose as your new save directory will have each of the two text and screenshot folders created automatically. 

Speaking of buttons, the buttons were changed. After adding 2 new buttons, they looked all out of order, so I rearranged them so that they'd look better. I will attach a screenshot. This was a real pain in the neck, so I might consider making a separate file that deals just with the UI in the future. 